### PR TITLE
bug-fix: don't reposition the special units at stop

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -259,13 +259,15 @@ public class Level {
             }
             stopNPCs();
             inProgress = false;
-            for (Player player : players) {
-                if (player.getLives() != 0) {
-                    player.setAlive(true);
+            if (!isAnyPlayerAlive()) {
+                for (Player player : players) {
+                    if (player.getLives() > 0) {
+                        player.setAlive(true);
+                    }
                 }
-            }
-            if (isAnyPlayerAlive()) {
-                setSpecialUnitsToInitialSquares();
+                if (isAnyPlayerAlive()) {
+                    setSpecialUnitsToInitialSquares();
+                }
             }
         }
     }


### PR DESCRIPTION
If there are any alive players, don't reposition the special units (ghosts and player) to their initial positions.